### PR TITLE
Use walk method to have better control ove copied files

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,9 +21,14 @@ program
     }
 
     try {
-      await createBlueprint(type, name, destination, configs)
+      const createdFiles = await createBlueprint(
+        type,
+        name,
+        destination,
+        configs
+      )
 
-      success(destination, name, type)
+      success(destination, name, type, createdFiles)
     } catch (e) {
       process.stderr.write(chalk.red(e.stack + '\n'))
     }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "prettier": "^1.13.5"
   },
   "createFromBlueprint": {
-    "component": "testProject/blueprints/{% component %}"
+    "component": "testProject/blueprints/component"
   }
 }

--- a/test.js
+++ b/test.js
@@ -12,14 +12,22 @@ import {
   createDirectory,
 } from './utils'
 
+// Mock-fs didn't work properly for these tests. I never could find out the
+// reason, but the test process could be made a lot more simple if iy could be
+// used to mock the filesystem.
+
 test.before(() => {
   const notRelative = (p) => path.resolve(process.cwd(), p)
 
   if (!fs.existsSync(notRelative('blueprints'))) {
     fs.mkdirSync(notRelative('blueprints'))
-    fs.mkdirSync(notRelative('blueprints/{% component %}'))
+    fs.mkdirSync(notRelative('blueprints/component'))
+    fs.mkdirSync(notRelative('blueprints/component/{% component %}'))
     fs.writeFileSync(
-      notRelative('blueprints/{% component %}/{% Component %}.js', 'Content')
+      notRelative(
+        'blueprints/component/{% component %}/{% Component %}.js',
+        'Content'
+      )
     )
   }
 
@@ -39,14 +47,14 @@ test.after.always(() => {
 test('createBlueprint', async (t) => {
   t.truthy(createBlueprint, 'should be defined')
 
-  if (!fs.existsSync('blueprints/{% component %}')) {
-    t.fails('The file should be created')
+  if (!fs.existsSync('blueprints/component/{% component %}')) {
+    t.fail('The file should be created')
   }
 
   const targetDir = 'src/components'
   const name = 'someComponent'
   const configs = {
-    component: 'blueprints/{% component %}',
+    component: 'blueprints/component',
   }
 
   try {
@@ -57,7 +65,7 @@ test('createBlueprint', async (t) => {
   }
 
   const err = await new Promise((resolve) => {
-    fs.stat(`${targetDir}`, (err) => {
+    fs.stat(`${targetDir}/${name}`, (err) => {
       if (err) {
         return resolve(err)
       }

--- a/testProject/blueprints/component/{% component %}/{% Component %}.js
+++ b/testProject/blueprints/component/{% component %}/{% Component %}.js
@@ -1,0 +1,3 @@
+import React from 'react'
+
+export const Component = ({}) => <div />

--- a/testProject/test.js
+++ b/testProject/test.js
@@ -33,7 +33,8 @@ test('cli tool', async (t) => {
   const files = fs.readdirSync('testProject/src/components/invoiceItem')
 
   t.true(
-    files.includes('InvoiceItem.js'),
+    files.includes('InvoiceItem.js') && files.includes('InvoiceItem.spec.js'),
+    files.includes('subComponents'),
     'Should create file with correct case'
   )
 })


### PR DESCRIPTION
Previosuly the config path from the blueprint setting would be
processed, but after this change only those parts of the filepath which
are contained within the blueprint config directory are processed.
This enables better separation of concerns which enabled various
unwanted behaviour to be discarded.

These are still separation of concern issues to be dealt with.